### PR TITLE
add mode parameter to fopen callback

### DIFF
--- a/psflib.c
+++ b/psflib.c
@@ -419,7 +419,7 @@ static int psf_load_internal( psf_load_state * state, const char * file_name )
     strcat( full_path, file_name );
 #endif
 
-    file = state->file_callbacks->fopen( full_path );
+    file = state->file_callbacks->fopen( full_path, "rb" );
 
     free( full_path );
 

--- a/psflib.h
+++ b/psflib.h
@@ -39,7 +39,7 @@ typedef struct psf_file_callbacks
     const char * path_separators;
 
     /* accepts UTF-8 encoding, returns file handle */
-    void * (* fopen )(const char *);
+    void * (* fopen )(const char *, const char * mode);
 
     /* reads to specified buffer, returns count of size bytes read */
     size_t (* fread )(void *, size_t size, size_t count, void * handle);


### PR DESCRIPTION
currently the client needs to know how to open a psf file. let that decision up to psflib.